### PR TITLE
BDOG-691: Tests, and a slight restructuring

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,8 +32,17 @@ lazy val library = Project(name, file("."))
     crossScalaVersions := Seq.empty
   )
   .aggregate(
+    cookieBannerCommon,
     cookieBannerPlay25,
     cookieBannerPlay26
+  )
+
+lazy val cookieBannerCommon = Project("cookie-banner-common", file("cookie-banner-common"))
+  .enablePlugins(SbtAutoBuildPlugin, SbtArtifactory)
+  .settings(
+    commonSettings,
+    crossScalaVersions := Seq(scala2_11),
+    libraryDependencies ++= AppDependencies.cookieBannerCommon
   )
 
 lazy val cookieBannerPlay25 = Project("cookie-banner-play-25", file("cookie-banner-play-25"))
@@ -42,11 +51,11 @@ lazy val cookieBannerPlay25 = Project("cookie-banner-play-25", file("cookie-bann
     commonSettings,
     crossScalaVersions := Seq(scala2_11),
     libraryDependencies ++= AppDependencies.cookieBannerPlay25
-  )
+  ).dependsOn(cookieBannerCommon % "test->test;compile->compile")
 
 lazy val cookieBannerPlay26 = Project("cookie-banner-play-26", file("cookie-banner-play-26"))
   .enablePlugins(SbtAutoBuildPlugin, SbtArtifactory)
   .settings(
     commonSettings,
     libraryDependencies ++= AppDependencies.cookieBannerPlay26
-  )
+  ).dependsOn(cookieBannerCommon % "test->test;compile->compile")

--- a/cookie-banner-common/src/test/scala/uk/gov/hmrc/cookiebanner/WireMockEndpoints.scala
+++ b/cookie-banner-common/src/test/scala/uk/gov/hmrc/cookiebanner/WireMockEndpoints.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cookiebanner
+
+import java.net.ServerSocket
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.{MappingBuilder, ResponseDefinitionBuilder, WireMock}
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration._
+import com.github.tomakehurst.wiremock.http.RequestMethod
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Suite}
+
+import scala.util.Try
+
+trait WireMockEndpoints extends Suite with BeforeAndAfterAll with BeforeAndAfterEach {
+
+  val wireMockHost: String = "localhost"
+  val wireMockPort: Int = PortTester.findPort()
+  val wireMock = new WireMock(wireMockHost, wireMockPort)
+
+  private val wireMockServer = new WireMockServer(wireMockConfig().port(wireMockPort))
+
+  def startWireMock(): Unit = wireMockServer.start()
+  def stopWireMock(): Unit = wireMockServer.stop()
+
+  def partialEndpoint(url: String, willRespondWith: (Int, Option[String])): Unit = {
+    val builder = new MappingBuilder(RequestMethod.GET, urlEqualTo(url))
+    val response = new ResponseDefinitionBuilder()
+      .withStatus(willRespondWith._1)
+    val resp = willRespondWith._2.map(response.withBody).getOrElse(response)
+    builder.willReturn(resp)
+
+    wireMock.register(builder)
+  }
+
+  override def beforeEach(): Unit = {
+    wireMock.resetMappings()
+    wireMock.resetScenarios()
+  }
+  override def afterAll(): Unit =
+    wireMockServer.stop()
+  override def beforeAll(): Unit = {
+    println(s"starting endpoint server on $wireMockPort")
+    wireMockServer.start()
+  }
+
+}
+
+private object PortTester {
+
+  def findPort(excluded: Int*): Int =
+    (6001 to 7000).find(port => !excluded.contains(port) && isFree(port)).getOrElse(throw new Exception("No free port"))
+
+  private def isFree(port: Int): Boolean = {
+    val triedSocket = Try {
+      val serverSocket = new ServerSocket(port)
+      Try(serverSocket.close())
+      serverSocket
+    }
+    triedSocket.isSuccess
+  }
+}

--- a/cookie-banner-play-25/src/main/resources/reference.conf
+++ b/cookie-banner-play-25/src/main/resources/reference.conf
@@ -1,0 +1,20 @@
+# Copyright 2020 HM Revenue & Customs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cookie-banner {
+  protocol = http
+  host = localhost
+  port = 9001
+  path = "/tracking-consent/consent-head"
+}

--- a/cookie-banner-play-25/src/main/scala/uk/gov/hmrc/cookiebanner/CookieBanner.scala
+++ b/cookie-banner-play-25/src/main/scala/uk/gov/hmrc/cookiebanner/CookieBanner.scala
@@ -27,37 +27,48 @@ import uk.gov.hmrc.http.{CoreGet, HttpGet}
 import uk.gov.hmrc.play.http.ws.WSGet
 import uk.gov.hmrc.play.partials.CachedStaticHtmlPartialRetriever
 
-case class CookieConfig(protocol: String, host: String, port: Int, path: String)
+import scala.concurrent.duration._
 
-class CookieBanner @Inject() (http: WSGet, config: Configuration) extends CachedStaticHtmlPartialRetriever {
+class CookieBanner @Inject() (http: CoreGet, config: Configuration) extends CachedStaticHtmlPartialRetriever {
   override def httpGet: CoreGet = http
-  private val partialUrl: Option[String] = config.getString("cookie-banner-url")
+  private val partialUrl: Option[String] = config.getString("cookie-banner.url")
+
+  override def refreshAfter: Duration = {
+    config.getMilliseconds("cookie-banner.refreshAfter")
+      .map(_.millisecond)
+      .getOrElse(super.refreshAfter)
+  }
+
+  override def expireAfter: Duration = {
+    config.getMilliseconds("cookie-banner.expireAfter")
+      .map(_.millisecond)
+      .getOrElse(super.expireAfter)
+  }
 
   def cookieBanner(implicit req: RequestHeader): Html =
     partialUrl
       .map(loadPartial(_).successfulContentOrEmpty)
       .getOrElse {
-        Logger.logger.warn("cookie-banner-url is not configured")
+        Logger.logger.warn("cookie-banner.url is not configured")
         Html("")
       }
 }
 
-object WSHttp extends HttpGet with WSGet {
-  override protected def actorSystem: ActorSystem = Play.current.actorSystem
-  override protected def configuration: Option[Config] = Some(Play.current.configuration.underlying)
-  override val hooks: Seq[HttpHook] = NoneRequired
-}
+/**
+ * Utility object to allow Play2.5 services that do not yet use dependency-injection
+ * to use the CookieBanner library with minimal effort.
+ *
+ * It is preferable to use the `CookieBanner` class, and inject it into
+ * a template, rather than this static method.
+ */
+object CookieBannerStatic {
 
-object CookieBannerStatic extends CachedStaticHtmlPartialRetriever {
-  private val config = Play.current.configuration
-  override def httpGet: CoreGet = WSHttp
-  private val partialUrl = config.getString("cookie-banner-url")
+  private object WSHttp extends HttpGet with WSGet {
+    override protected def actorSystem: ActorSystem = Play.current.actorSystem
+    override protected def configuration: Option[Config] = Some(Play.current.configuration.underlying)
+    override val hooks: Seq[HttpHook] = NoneRequired
+  }
+  private val instance = new CookieBanner(WSHttp, Play.current.configuration)
 
-  def cookieBanner(implicit req: RequestHeader): Html =
-    partialUrl
-      .map(loadPartial(_).successfulContentOrEmpty)
-      .getOrElse {
-        Logger.logger.warn("cookie-banner-url is not configured")
-        Html("")
-      }
+  def cookieBanner(implicit req: RequestHeader): Html = instance.cookieBanner
 }

--- a/cookie-banner-play-25/src/main/scala/uk/gov/hmrc/cookiebanner/CookieBanner.scala
+++ b/cookie-banner-play-25/src/main/scala/uk/gov/hmrc/cookiebanner/CookieBanner.scala
@@ -30,26 +30,22 @@ import uk.gov.hmrc.play.partials.CachedStaticHtmlPartialRetriever
 import scala.concurrent.duration._
 
 class CookieBanner @Inject() (http: CoreGet, config: Configuration) extends CachedStaticHtmlPartialRetriever {
+
+  private val cookieBannerConfig = new CookieBannerConfig(config)
+
   override def httpGet: CoreGet = http
-  private val partialUrl: Option[String] = config.getString("cookie-banner.url")
 
-  override def refreshAfter: Duration = {
-    config.getMilliseconds("cookie-banner.refreshAfter")
-      .map(_.millisecond)
-      .getOrElse(super.refreshAfter)
-  }
+  override def refreshAfter: Duration =
+    cookieBannerConfig.cacheRefreshAfter.getOrElse(super.refreshAfter)
 
-  override def expireAfter: Duration = {
-    config.getMilliseconds("cookie-banner.expireAfter")
-      .map(_.millisecond)
-      .getOrElse(super.expireAfter)
-  }
+  override def expireAfter: Duration =
+    cookieBannerConfig.cacheExpireAfter.getOrElse(super.expireAfter)
 
   def cookieBanner(implicit req: RequestHeader): Html =
-    partialUrl
+    cookieBannerConfig.partialUrl
       .map(loadPartial(_).successfulContentOrEmpty)
       .getOrElse {
-        Logger.logger.warn("cookie-banner.url is not configured")
+        Logger.logger.warn("cookie-banner is not configured")
         Html("")
       }
 }

--- a/cookie-banner-play-25/src/main/scala/uk/gov/hmrc/cookiebanner/CookieBannerConfig.scala
+++ b/cookie-banner-play-25/src/main/scala/uk/gov/hmrc/cookiebanner/CookieBannerConfig.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cookiebanner
+
+import play.api.Configuration
+
+import scala.concurrent.duration._
+
+class CookieBannerConfig(configuration: Configuration) {
+  def partialUrl: Option[String] = {
+    val hostOpt: Option[String] = configuration.getString("cookie-banner.host")
+    val pathOpt: Option[String] = configuration.getString("cookie-banner.path")
+
+    val protocol = configuration.getString("cookie-banner.protocol").getOrElse("https")
+    val port     = configuration.getInt("cookie-banner.port").getOrElse(443)
+
+    (hostOpt, pathOpt) match {
+      case (Some(host), Some(path)) =>
+        Some(s"$protocol://$host:$port$path")
+      case _ => None
+    }
+  }
+
+  def cacheRefreshAfter: Option[Duration] =
+    configuration.getMilliseconds("cookie-banner.refreshAfter").map(_.millisecond)
+
+  def cacheExpireAfter: Option[Duration] =
+    configuration.getMilliseconds("cookie-banner.expireAfter").map(_.millisecond)
+}

--- a/cookie-banner-play-25/src/test/scala/uk/gov/hmrc/cookiebanner/CookieBanner25Spec.scala
+++ b/cookie-banner-play-25/src/test/scala/uk/gov/hmrc/cookiebanner/CookieBanner25Spec.scala
@@ -34,13 +34,19 @@ import uk.gov.hmrc.play.http.ws.WSHttp
 class CookieBanner25Spec extends AnyFreeSpec with Matchers
   with WireMockEndpoints with GuiceOneAppPerSuite {
 
+  val config = Configuration(
+    "cookie-banner.host" -> wireMockHost,
+    "cookie-banner.port" -> wireMockPort.toString,
+    "cookie-banner.path" -> "/tracking-consent",
+    "cookie-banner.protocol" -> "http"
+  )
+
+  override def fakeApplication(): Application = {
+    new GuiceApplicationBuilder().configure(config).build()
+  }
+
   private val ws = app.injector.instanceOf[WSClient]
   private val actorSystem = app.injector.instanceOf[ActorSystem]
-
-  override def fakeApplication(): Application =
-    new GuiceApplicationBuilder().configure(Map("cookie-banner.url" -> s"http://$wireMockHost:$wireMockPort/tracking-consent")).build()
-
-  private val config = Configuration("cookie-banner.url" -> s"http://$wireMockHost:$wireMockPort/tracking-consent")
 
   private def cookieBanner(config: Configuration) = {
     implicit val fakeRequest: RequestHeader = FakeRequest()

--- a/cookie-banner-play-25/src/test/scala/uk/gov/hmrc/cookiebanner/CookieBannerConfigSpec.scala
+++ b/cookie-banner-play-25/src/test/scala/uk/gov/hmrc/cookiebanner/CookieBannerConfigSpec.scala
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cookiebanner
+
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.Configuration
+import scala.concurrent.duration._
+
+class CookieBannerConfigSpec extends AnyFreeSpec with Matchers {
+
+  "CookieBannerConfig" - {
+    "partialUrl" - {
+      "should return value with all options configured" in {
+        val config = Configuration(
+          "cookie-banner.protocol" -> "http",
+          "cookie-banner.host" -> "localhost",
+          "cookie-banner.port" -> "8080",
+          "cookie-banner.path" -> "/get-my-cookies"
+        )
+        val underTest = new CookieBannerConfig(config)
+        underTest.partialUrl shouldBe Some("http://localhost:8080/get-my-cookies")
+      }
+
+      "return None if host is missing" in {
+        val config = Configuration(
+          "cookie-banner.protocol" -> "http",
+          "cookie-banner.port" -> "8080",
+          "cookie-banner.path" -> "/get-my-cookies"
+        )
+        val underTest = new CookieBannerConfig(config)
+        underTest.partialUrl shouldBe None
+      }
+
+      "return None if path is missing" in {
+        val config = Configuration(
+          "cookie-banner.protocol" -> "http",
+          "cookie-banner.host" -> "localhost",
+          "cookie-banner.port" -> "8080"
+        )
+        val underTest = new CookieBannerConfig(config)
+        underTest.partialUrl shouldBe None
+      }
+
+      "default protocol if missing" in {
+        val config = Configuration(
+          "cookie-banner.host" -> "localhost",
+          "cookie-banner.port" -> "8080",
+          "cookie-banner.path" -> "/get-my-cookies"
+        )
+        val underTest = new CookieBannerConfig(config)
+        underTest.partialUrl shouldBe Some("https://localhost:8080/get-my-cookies")
+      }
+
+      "default port if missing" in {
+        val config = Configuration(
+          "cookie-banner.protocol" -> "http",
+          "cookie-banner.host" -> "localhost",
+          "cookie-banner.path" -> "/get-my-cookies"
+        )
+        val underTest = new CookieBannerConfig(config)
+        underTest.partialUrl shouldBe Some("http://localhost:443/get-my-cookies")
+      }
+    }
+
+    "cacheRefreshAfter" - {
+      "should load from config" in {
+        val config = Configuration(
+          "cookie-banner.refreshAfter" -> "1 minute"
+        )
+        new CookieBannerConfig(config).cacheRefreshAfter shouldBe Some(1 minute)
+      }
+
+      "return None if not configured" in {
+        val config = Configuration.empty
+        new CookieBannerConfig(config).cacheRefreshAfter shouldBe None
+      }
+    }
+
+    "cacheExpireAfter" - {
+      "should load from config" in {
+        val config = Configuration(
+          "cookie-banner.expireAfter" -> "1 minute"
+        )
+        new CookieBannerConfig(config).cacheExpireAfter shouldBe Some(1 minute)
+      }
+
+      "return None if not configured" in {
+        val config = Configuration.empty
+        new CookieBannerConfig(config).cacheExpireAfter shouldBe None
+      }
+    }
+  }
+}

--- a/cookie-banner-play-26/src/main/resources/reference.conf
+++ b/cookie-banner-play-26/src/main/resources/reference.conf
@@ -1,0 +1,20 @@
+# Copyright 2020 HM Revenue & Customs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cookie-banner {
+  protocol = http
+  host = localhost
+  port = 9001
+  path = "/tracking-consent/consent-head"
+}

--- a/cookie-banner-play-26/src/main/scala/uk/gov/hmrc/cookiebanner/CookieBanner.scala
+++ b/cookie-banner-play-26/src/main/scala/uk/gov/hmrc/cookiebanner/CookieBanner.scala
@@ -26,24 +26,22 @@ import uk.gov.hmrc.play.partials.CachedStaticHtmlPartialRetriever
 import scala.concurrent.duration.Duration
 
 class CookieBanner @Inject() (http: CoreGet, config: Configuration) extends CachedStaticHtmlPartialRetriever {
+
+  private val cookieBannerConfig = new CookieBannerConfig(config)
+
   override def httpGet: CoreGet = http
-  private val partialUrl: Option[String] = config.getOptional[String]("cookie-banner.url")
 
-  override def refreshAfter: Duration = {
-    config.getOptional[Duration]("cookie-banner.refreshAfter")
-      .getOrElse(super.refreshAfter)
-  }
+  override def refreshAfter: Duration =
+    cookieBannerConfig.cacheRefreshAfter.getOrElse(super.refreshAfter)
 
-  override def expireAfter: Duration = {
-    config.getOptional[Duration]("cookie-banner.expireAfter")
-      .getOrElse(super.expireAfter)
-  }
+  override def expireAfter: Duration =
+    cookieBannerConfig.cacheExpireAfter.getOrElse(super.expireAfter)
 
   def cookieBanner(implicit req: RequestHeader): Html =
-    partialUrl
+    cookieBannerConfig.partialUrl
       .map(loadPartial(_).successfulContentOrEmpty)
       .getOrElse {
-        Logger.logger.warn("cookie-banner.url is not configured")
+        Logger.logger.warn("cookie-banner is not configured")
         Html("")
       }
 }

--- a/cookie-banner-play-26/src/main/scala/uk/gov/hmrc/cookiebanner/CookieBanner.scala
+++ b/cookie-banner-play-26/src/main/scala/uk/gov/hmrc/cookiebanner/CookieBanner.scala
@@ -21,18 +21,29 @@ import play.api.{Configuration, Logger}
 import play.api.mvc.RequestHeader
 import play.twirl.api.Html
 import uk.gov.hmrc.http.CoreGet
-import uk.gov.hmrc.play.http.ws.WSGet
 import uk.gov.hmrc.play.partials.CachedStaticHtmlPartialRetriever
 
-class CookieBanner @Inject() (http: WSGet, config: Configuration) extends CachedStaticHtmlPartialRetriever {
+import scala.concurrent.duration.Duration
+
+class CookieBanner @Inject() (http: CoreGet, config: Configuration) extends CachedStaticHtmlPartialRetriever {
   override def httpGet: CoreGet = http
-  private val partialUrl: Option[String] = config.getOptional[String]("cookie-banner-url")
+  private val partialUrl: Option[String] = config.getOptional[String]("cookie-banner.url")
+
+  override def refreshAfter: Duration = {
+    config.getOptional[Duration]("cookie-banner.refreshAfter")
+      .getOrElse(super.refreshAfter)
+  }
+
+  override def expireAfter: Duration = {
+    config.getOptional[Duration]("cookie-banner.expireAfter")
+      .getOrElse(super.expireAfter)
+  }
 
   def cookieBanner(implicit req: RequestHeader): Html =
     partialUrl
       .map(loadPartial(_).successfulContentOrEmpty)
       .getOrElse {
-        Logger.logger.warn("cookie-banner-url is not configured")
+        Logger.logger.warn("cookie-banner.url is not configured")
         Html("")
       }
 }

--- a/cookie-banner-play-26/src/main/scala/uk/gov/hmrc/cookiebanner/CookieBannerConfig.scala
+++ b/cookie-banner-play-26/src/main/scala/uk/gov/hmrc/cookiebanner/CookieBannerConfig.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cookiebanner
+
+import play.api.Configuration
+
+import scala.concurrent.duration._
+
+class CookieBannerConfig(configuration: Configuration) {
+  def partialUrl: Option[String] = {
+    val hostOpt: Option[String] = configuration.getOptional[String]("cookie-banner.host")
+    val pathOpt: Option[String] = configuration.getOptional[String]("cookie-banner.path")
+
+    val protocol = configuration.getOptional[String]("cookie-banner.protocol").getOrElse("https")
+    val port     = configuration.getOptional[Int]("cookie-banner.port").getOrElse(443)
+
+    (hostOpt, pathOpt) match {
+      case (Some(host), Some(path)) =>
+        Some(s"$protocol://$host:$port$path")
+      case _ => None
+    }
+  }
+
+  def cacheRefreshAfter: Option[Duration] =
+    configuration.getOptional[Duration]("cookie-banner.refreshAfter")
+
+  def cacheExpireAfter: Option[Duration] =
+    configuration.getOptional[Duration]("cookie-banner.expireAfter")
+}

--- a/cookie-banner-play-26/src/test/scala/uk/gov/hmrc/cookiebanner/CookieBanner26Spec.scala
+++ b/cookie-banner-play-26/src/test/scala/uk/gov/hmrc/cookiebanner/CookieBanner26Spec.scala
@@ -36,7 +36,12 @@ class CookieBanner26Spec extends AnyFreeSpec with Matchers
   private val ws = app.injector.instanceOf[WSClient]
   private val actorSystem = app.injector.instanceOf[ActorSystem]
 
-  private val config = Configuration("cookie-banner.url" -> s"http://$wireMockHost:$wireMockPort/tracking-consent")
+  private val config = Configuration(
+    "cookie-banner.host" -> wireMockHost,
+    "cookie-banner.port" -> wireMockPort,
+    "cookie-banner.path" -> "/tracking-consent",
+    "cookie-banner.protocol" -> "http"
+  )
 
   private def cookieBanner(config: Configuration) = {
     implicit val fakeRequest: RequestHeader = FakeRequest()

--- a/cookie-banner-play-26/src/test/scala/uk/gov/hmrc/cookiebanner/CookieBanner26Spec.scala
+++ b/cookie-banner-play-26/src/test/scala/uk/gov/hmrc/cookiebanner/CookieBanner26Spec.scala
@@ -16,14 +16,64 @@
 
 package uk.gov.hmrc.cookiebanner
 
+import akka.actor.ActorSystem
+import com.typesafe.config.Config
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Configuration
+import play.api.libs.ws.WSClient
+import play.api.mvc.RequestHeader
+import play.api.test.FakeRequest
+import play.twirl.api.Html
+import uk.gov.hmrc.http.hooks.HttpHook
+import uk.gov.hmrc.http._
+import uk.gov.hmrc.play.http.ws.WSHttp
 
-class CookieBanner26Spec extends AnyFreeSpec with Matchers {
+class CookieBanner26Spec extends AnyFreeSpec with Matchers
+  with WireMockEndpoints with GuiceOneAppPerSuite {
+
+  private val ws = app.injector.instanceOf[WSClient]
+  private val actorSystem = app.injector.instanceOf[ActorSystem]
+
+  private val config = Configuration("cookie-banner.url" -> s"http://$wireMockHost:$wireMockPort/tracking-consent")
+
+  private def cookieBanner(config: Configuration) = {
+    implicit val fakeRequest: RequestHeader = FakeRequest()
+    // create a new CookieBanner for each test, to avoid caching
+    new CookieBanner(new DefaultHttpClient(config, ws, actorSystem), config).cookieBanner
+  }
 
   "CookieBanner" - {
-    "1 shouldBe 1" in {
-      1 shouldBe 1
+    "should retrieve partial" in {
+      partialEndpoint("/tracking-consent",
+        willRespondWith = (
+          200,
+          Some("<p>Some partial content</p>")))
+
+      cookieBanner(config) shouldBe Html("<p>Some partial content</p>")
+    }
+
+    "should return empty Html on error from cookie-banner-url" in {
+      partialEndpoint("/tracking-consent",
+        willRespondWith = (
+          404,
+          None))
+
+      cookieBanner(config) shouldBe Html("")
+    }
+
+    "should return empty Html if configuration is not set" in {
+      cookieBanner(Configuration.empty) shouldBe Html("")
     }
   }
+}
+
+// this snippet is taken from play-bootstrap. we don't want a dependency on play-bootstrap in this library though
+trait HttpClient extends HttpGet with HttpPut with HttpPost with HttpDelete with HttpPatch
+class DefaultHttpClient(config: Configuration,
+                        override val wsClient: WSClient,
+                        override protected val actorSystem: ActorSystem) extends HttpClient with WSHttp {
+  override lazy val configuration: Option[Config] = Option(config.underlying)
+  override val hooks: Seq[HttpHook] = Seq()
 }

--- a/cookie-banner-play-26/src/test/scala/uk/gov/hmrc/cookiebanner/CookieBannerConfigSpec.scala
+++ b/cookie-banner-play-26/src/test/scala/uk/gov/hmrc/cookiebanner/CookieBannerConfigSpec.scala
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cookiebanner
+
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.Configuration
+
+import scala.concurrent.duration._
+
+class CookieBannerConfigSpec extends AnyFreeSpec with Matchers {
+
+  "CookieBannerConfig" - {
+    "partialUrl" - {
+      "should return value with all options configured" in {
+        val config = Configuration(
+          "cookie-banner.protocol" -> "http",
+          "cookie-banner.host" -> "localhost",
+          "cookie-banner.port" -> "8080",
+          "cookie-banner.path" -> "/get-my-cookies"
+        )
+        val underTest = new CookieBannerConfig(config)
+        underTest.partialUrl shouldBe Some("http://localhost:8080/get-my-cookies")
+      }
+
+      "return None if host is missing" in {
+        val config = Configuration(
+          "cookie-banner.protocol" -> "http",
+          "cookie-banner.port" -> "8080",
+          "cookie-banner.path" -> "/get-my-cookies"
+        )
+        val underTest = new CookieBannerConfig(config)
+        underTest.partialUrl shouldBe None
+      }
+
+      "return None if path is missing" in {
+        val config = Configuration(
+          "cookie-banner.protocol" -> "http",
+          "cookie-banner.host" -> "localhost",
+          "cookie-banner.port" -> "8080"
+        )
+        val underTest = new CookieBannerConfig(config)
+        underTest.partialUrl shouldBe None
+      }
+
+      "default protocol if missing" in {
+        val config = Configuration(
+          "cookie-banner.host" -> "localhost",
+          "cookie-banner.port" -> "8080",
+          "cookie-banner.path" -> "/get-my-cookies"
+        )
+        val underTest = new CookieBannerConfig(config)
+        underTest.partialUrl shouldBe Some("https://localhost:8080/get-my-cookies")
+      }
+
+      "default port if missing" in {
+        val config = Configuration(
+          "cookie-banner.protocol" -> "http",
+          "cookie-banner.host" -> "localhost",
+          "cookie-banner.path" -> "/get-my-cookies"
+        )
+        val underTest = new CookieBannerConfig(config)
+        underTest.partialUrl shouldBe Some("http://localhost:443/get-my-cookies")
+      }
+    }
+
+    "cacheRefreshAfter" - {
+      "should load from config" in {
+        val config = Configuration(
+          "cookie-banner.refreshAfter" -> "1 minute"
+        )
+        new CookieBannerConfig(config).cacheRefreshAfter shouldBe Some(1 minute)
+      }
+
+      "return None if not configured" in {
+        val config = Configuration.empty
+        new CookieBannerConfig(config).cacheRefreshAfter shouldBe None
+      }
+    }
+
+    "cacheExpireAfter" - {
+      "should load from config" in {
+        val config = Configuration(
+          "cookie-banner.expireAfter" -> "1 minute"
+        )
+        new CookieBannerConfig(config).cacheExpireAfter shouldBe Some(1 minute)
+      }
+
+      "return None if not configured" in {
+        val config = Configuration.empty
+        new CookieBannerConfig(config).cacheExpireAfter shouldBe None
+      }
+    }
+  }
+}

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,18 +2,25 @@ import sbt._
 
 object AppDependencies {
 
-  lazy val test: Seq[ModuleID] = Seq(
-    "org.scalatest"        %% "scalatest"                % "3.1.0"        % Test,
-    "com.vladsch.flexmark" % "flexmark-all"              % "0.35.10"      % Test,
-    "ch.qos.logback"       % "logback-classic"           % "1.2.3"        % Test,
+  lazy val testCommon: Seq[ModuleID] = Seq(
+    "org.scalatest"          %% "scalatest"          % "3.1.0"    % Test,
+    "com.vladsch.flexmark"   %  "flexmark-all"       % "0.35.10"  % Test,
+    "ch.qos.logback"         %  "logback-classic"    % "1.2.3"    % Test,
+    "com.github.tomakehurst" %  "wiremock"           % "1.58"     % Test,
   )
 
+  lazy val cookieBannerCommon: Seq[ModuleID] = testCommon
+
+  // https://github.com/playframework/scalatestplus-play#releases
   lazy val cookieBannerPlay25: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc" %% "play-partials" % "6.9.0-play-25"
-  ) ++ test
+    "uk.gov.hmrc" %% "play-partials" % "6.9.0-play-25",
+  ) ++ testCommon ++ Seq(
+    "org.scalatestplus.play" %% "scalatestplus-play" % "2.0.1" % Test,
+  )
 
   lazy val cookieBannerPlay26: Seq[ModuleID] = Seq(
     "uk.gov.hmrc" %% "play-partials" % "6.9.0-play-26"
-  ) ++ test
+  ) ++ testCommon ++ Seq(
+    "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.3" % Test,
+  )
 }
-


### PR DESCRIPTION
There is a slight disconnect in the design of this, as Bootstrap
contains the DefaultHttpClient, and this library does not depend on
Bootstrap. Therefore, to make it work, Guice'd applications would
currently have to define this module:

    import play.api.{Configuration, Environment}
    import play.api.inject.{Binding, Module}
    import uk.gov.hmrc.http.CoreGet
    import uk.gov.hmrc.play.bootstrap.http.DefaultHttpClient

    class CookieModule extends Module {
      override def bindings(environment: Environment, configuration: Configuration): Seq[Binding[_]] = Seq(
        bind[CoreGet].to[DefaultHttpClient]
      )
    }

CoreGet exists in http-verbs, so I had based the interface from that.
However, the actual implementation of this trait is
`DefaultHttpClient`...

I imagine there'll be another PR for this library soon, once we design
around this issue.